### PR TITLE
Fix errors on Windows Server 2016.

### DIFF
--- a/lib/facter/windows_disks.rb
+++ b/lib/facter/windows_disks.rb
@@ -4,13 +4,17 @@ Facter.add('disks') do
   require_relative '../puppet_x/disk_facts/underscore.rb'
   require 'json'
   setcode do
+    kernelmajversion = Facter.value('kernelmajversion')
+    next if kernelmajversion == '6.0' # Get-disk is not available on Windows Server 2008
+    next if kernelmajversion == '6.1' # Get-disk is not available on Windows Server 2008 R2
+
     disks_hashes = JSON.parse(Facter::Core::Execution.exec('powershell.exe -Command "Get-Disk | select *  -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress"'))
     disks_hashes_renamed = []
     out = {}
 
     # Make sure that we can handle only one disk
     disks_hashes = [disks_hashes] if disks_hashes.kind_of?(Hash)
-    
+
     # Change camel case to unserscores
     disks_hashes.each do |disk|
       current_disk_renamed = {}

--- a/lib/facter/windows_disks.rb
+++ b/lib/facter/windows_disks.rb
@@ -4,7 +4,7 @@ Facter.add('disks') do
   require_relative '../puppet_x/disk_facts/underscore.rb'
   require 'json'
   setcode do
-    disks_hashes = JSON.parse(Facter::Core::Execution.exec('powershell.exe -Command "Get-Disk | select *  -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 999 -Compress"'))
+    disks_hashes = JSON.parse(Facter::Core::Execution.exec('powershell.exe -Command "Get-Disk | select *  -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress"'))
     disks_hashes_renamed = []
     out = {}
 

--- a/lib/facter/windows_drives.rb
+++ b/lib/facter/windows_drives.rb
@@ -4,7 +4,7 @@ Facter.add('drives') do
   require_relative '../puppet_x/disk_facts/underscore.rb'
   require 'json'
   setcode do
-    drives = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-PSDrive -PSProvider 'FileSystem' | Select-Object * -ExcludeProperty Provider,Credential,CurrentLocation | ConvertTo-Json -Depth 999 -Compress\""))
+    drives = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-PSDrive -PSProvider 'FileSystem' | Select-Object * -ExcludeProperty Provider,Credential,CurrentLocation | ConvertTo-Json -Depth 100 -Compress\""))
     drives_renamed = []
     out = {}
 

--- a/lib/facter/windows_partitions.rb
+++ b/lib/facter/windows_partitions.rb
@@ -4,7 +4,7 @@ Facter.add('partitions') do
   require_relative '../puppet_x/disk_facts/underscore.rb'
   require 'json'
   setcode do
-    partitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 999 -Compress\""))
+    partitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress\""))
     partitions_renamed = []
 
     # Make sure that we can handle only one partition

--- a/lib/facter/windows_partitions.rb
+++ b/lib/facter/windows_partitions.rb
@@ -4,6 +4,10 @@ Facter.add('partitions') do
   require_relative '../puppet_x/disk_facts/underscore.rb'
   require 'json'
   setcode do
+    kernelmajversion = Facter.value('kernelmajversion')
+    next if kernelmajversion == '6.0' # Get-Partition is not available on Windows Server 2008
+    next if kernelmajversion == '6.1' # Get-Partition is not available on Windows Server 2008 R2
+
     partitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress\""))
     partitions_renamed = []
 


### PR DESCRIPTION
This solves `error while resolving custom fact "disks": A JSON text must at least contain two octets!` on Windows Server 2016.

`ConvertTo-Json` says _The maximum depth allowed for serialization is 100" on Windows Server 2016_.
