### PR TITLE
Readded partition functionality for 2008 r2

### DIFF
--- a/lib/facter/windows_partitions.rb
+++ b/lib/facter/windows_partitions.rb
@@ -5,7 +5,13 @@ Facter.add('partitions') do
   require 'json'
   setcode do
 
-    partitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress\""))
+  # set windows 2008 to true/False
+  win2008 = Facter.value(:kernelmajversion) == '6.1' || Facter.value(:kernelmajversion) == '6.0'
+  result = if win2008 == true
+             partitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-PSDrive -PSProvider 'FileSystem' | Select-Object * -ExcludeProperty Provider,Credential,CurrentLocation | ConvertTo-Json -Depth 100 -Compress\""))
+           else
+             ppartitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress\""))
+           end
     partitions_renamed = []
 
     # Make sure that we can handle only one partition


### PR DESCRIPTION
````powershell
ppartitions = JSON.parse(Facter::Core::Execution.exec("powershell.exe -Command \"Get-Partition | Select-Object * -ExcludeProperty CimClass,CimInstanceProperties,CimSystemProperties | ConvertTo-Json -Depth 100 -Compress\""))
````
Is not a viable cmdlet on 2008 r2. When this module was run on 2008r2 server it failed with the following message.
"Error: Facter: error while resolving custom fact "partitions": A JSON text must
at least contain two octets!"

I added the following code to use the older command for 2008r2 and 2012 - 2016 will use get-partition.

This was tested on 2008r2, 2012,2012 r2, and 2016